### PR TITLE
[HOTFIX]: OAuth2 인증 후 리다이렉트 처리 및 사용자 정보 저장 기능 추가

### DIFF
--- a/.tanstack/tmp/cf7413dc-c50a7546ab029f036ccf2716c22ff560
+++ b/.tanstack/tmp/cf7413dc-c50a7546ab029f036ccf2716c22ff560
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/auth/callback')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  return <div>Hello "/auth/callback"!</div>
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,11 +2,27 @@ import { createFileRoute } from "@tanstack/react-router";
 import { redirect } from "@tanstack/react-router";
 import HomeLandingPage from "../pages/HomeLandingPage";
 import useUserInfoStore from "../store/userInfoStore";
+import { get } from "../api";
 
-const { isLogin } = useUserInfoStore.getState();
 export const Route = createFileRoute("/")({
-  beforeLoad: ({ location }) => {
+  beforeLoad: async ({ location, search }) => {
+    const { isLogin, setIsLogin } = useUserInfoStore.getState();
+    
+    // OAuth2 인증 완료 후 리다이렉트된 경우 (쿠키에 인증 정보가 있을 수 있음)
     if (location.pathname === "/" && !isLogin) {
+      try {
+        // 서버에서 사용자 정보 확인 (쿠키 기반 인증)
+        const response = await get("/members/me");
+        if (response.isSuccess && response.data) {
+          // 사용자 정보가 있으면 로그인 상태로 설정
+          setIsLogin(true);
+          return;
+        }
+      } catch (error) {
+        console.log("사용자 정보 확인 실패:", error);
+      }
+      
+      // 사용자 정보가 없으면 로그인 페이지로 리다이렉트
       throw redirect({ to: "/login" });
     }
   },

--- a/src/store/userInfoStore.ts
+++ b/src/store/userInfoStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
 interface UserInfo {
   isLogin: boolean;
@@ -9,13 +10,25 @@ interface UserInfo {
   setPetImage: (image: null | File) => void;
 }
 
-const useUserInfoStore = create<UserInfo>((set) => ({
-  isLogin: false,
-  setIsLogin: (value) => set({ isLogin: value }),
-  petAvatarId: 1,
-  setPetAvatarId: (id: number) => set({ petAvatarId: id }),
-  petImage: null,
-  setPetImage: (image: null | File) => set({ petImage: image }),
-}));
+const useUserInfoStore = create<UserInfo>()(
+  persist(
+    (set) => ({
+      isLogin: false,
+      setIsLogin: (value) => set({ isLogin: value }),
+      petAvatarId: 1,
+      setPetAvatarId: (id: number) => set({ petAvatarId: id }),
+      petImage: null,
+      setPetImage: (image: null | File) => set({ petImage: image }),
+    }),
+    {
+      name: "user-info-storage",
+      // petImage는 File 객체이므로 localStorage에 저장하지 않음
+      partialize: (state) => ({
+        isLogin: state.isLogin,
+        petAvatarId: state.petAvatarId,
+      }),
+    }
+  )
+);
 
 export default useUserInfoStore;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - OAuth 인증 처리를 위한 /auth/callback 경로가 추가되었습니다.
  - 사용자 정보가 브라우저에 영구 저장되어(필수 항목만) 로그인 상태가 재방문 시에도 유지됩니다.
- 버그 수정
  - 첫 진입 시 서버의 로그인 상태를 확인하여 자동 로그인 또는 /login으로의 안전한 이동이 일관되게 동작합니다.
  - OAuth 리다이렉트 이후 쿠키 기반 인증과 클라이언트 상태가 어긋나던 문제를 개선해 로그인 상태 동기화를 안정화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->